### PR TITLE
fix annoying warning

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -71,7 +71,7 @@ module.exports = ({ types: t }) => {
           ];
         }
 
-        path.replaceWithMultiple(replacement);
+        path.replaceWithMultiple(replacement).forEach(declaration => path.scope.registerDeclaration(declaration));
       }
     }
   };


### PR DESCRIPTION
Somehow the plugin generates some warning (possibly only when combined with babel typescript plugin) that can be annoying during dev.
```
The exported identifier "_$Component" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"_$Component" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
```
This should fix the issue.

As I lack experience with Babel and that there's no typing, I'm not 100% sure it has no side effects.
From my small tests, everything is working properly and the warning is gone,

I inspired myself from [this commit](https://github.com/gajus/babel-plugin-transform-export-default-name/pull/16/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556)